### PR TITLE
Initial admin UI for entering widgets to embed

### DIFF
--- a/classes/class-wp-nr-dashboard.php
+++ b/classes/class-wp-nr-dashboard.php
@@ -88,7 +88,7 @@ class WP_NR_Dashboard {
 			// Check if input posted for "additional dashboard widget" was valid
 			if ( ! empty( $add_dashboard_widget['embed_html'] ) &&
 				preg_match(
-					'#<iframe[^>]* src="https://insights-embed.newrelic.com/embedded_widget/([A-Za-z0-9]*)"#',
+					'#<iframe[^>]* src="https://insights-embed.newrelic.com/embedded_widget/([^/"]*)"#',
 					$add_dashboard_widget['embed_html'],
 					$embed_html_matches ) ) {
 

--- a/classes/class-wp-nr-dashboard.php
+++ b/classes/class-wp-nr-dashboard.php
@@ -35,7 +35,10 @@ class WP_NR_Dashboard {
 
 		wp_localize_script( 'nr-dashboard-widget-view', 'WP_NewRelic',
 			array(
-				'dashboardWidgets' => WP_NR_Helper::dashboard_widgets()
+				'dashboardWidgets' => WP_NR_Helper::dashboard_widgets(),
+				'strings' => array(
+					'delete' => esc_html__( 'Delete', 'wp-newrelic' )
+				),
 			)
 		);
 	}

--- a/classes/class-wp-nr-dashboard.php
+++ b/classes/class-wp-nr-dashboard.php
@@ -94,7 +94,7 @@ class WP_NR_Dashboard {
 
 				$dashboard_widgets[] = array(
 					'title'       => sanitize_text_field( $add_dashboard_widget['title'] ),
-					'embedID'    => $embed_html_matches[1],
+					'embedID'     => $embed_html_matches[1],
 					'description' => sanitize_text_field( $add_dashboard_widget['description'] )
 				);
 			}

--- a/classes/class-wp-nr-dashboard.php
+++ b/classes/class-wp-nr-dashboard.php
@@ -37,7 +37,8 @@ class WP_NR_Dashboard {
 			array(
 				'dashboardWidgets' => WP_NR_Helper::dashboard_widgets(),
 				'strings' => array(
-					'delete' => esc_html__( 'Delete', 'wp-newrelic' )
+					'delete'             => esc_html__( 'Delete', 'wp-newrelic' ),
+					'visualizationTitle' => esc_html__( 'Untitled Visualization', 'wp-newrelic' ),
 				),
 			)
 		);

--- a/classes/class-wp-nr-helper.php
+++ b/classes/class-wp-nr-helper.php
@@ -8,6 +8,15 @@
 class WP_NR_Helper {
 
 	/**
+	 * Retrieve the New Relic account ID, if user has entered it.
+	 *
+	 * @return string
+	 */
+	public static function nr_account_id() {
+		return get_option( 'wp_nr_account_id', '' );
+	}
+
+	/**
 	 * Check if capture url setting is enabled or not
 	 *
 	 * @return bool

--- a/classes/class-wp-nr-helper.php
+++ b/classes/class-wp-nr-helper.php
@@ -32,14 +32,14 @@ class WP_NR_Helper {
 	 * @return array array of dashboard widgets: [{
 	 *   @var string $title
 	 *   @var string $embed_id    Required
-	 *   @var string $description 
+	 *   @var string $description
 	 * }]
 	 */
     public static function dashboard_widgets() {
 		$dashboard_widgets = get_option( 'wp_nr_dashboard_widgets', array() );
 
 		return array_filter( $dashboard_widgets, function( $dashboard_widget ) {
-			return ! empty( $dashboard_widget['embed_id'] );
+			return ! empty( $dashboard_widget['embedID'] );
 		} );
     }
 

--- a/classes/class-wp-nr-helper.php
+++ b/classes/class-wp-nr-helper.php
@@ -27,6 +27,23 @@ class WP_NR_Helper {
 	}
 
 	/**
+	 * Get details of any registered dashboard widget embeddables
+	 *
+	 * @return array array of dashboard widgets: [{
+	 *   @var string $title
+	 *   @var string $embed_id    Required
+	 *   @var string $description 
+	 * }]
+	 */
+    public static function dashboard_widgets() {
+		$dashboard_widgets = get_option( 'wp_nr_dashboard_widgets', array() );
+
+		return array_filter( $dashboard_widgets, function( $dashboard_widget ) {
+			return ! empty( $dashboard_widget['embed_id'] );
+		} );
+    }
+
+	/**
 	 * Get single setting
 	 *
 	 * @param $setting
@@ -43,4 +60,5 @@ class WP_NR_Helper {
 
 		return $return;
 	}
+
 }

--- a/js/src/dashboard-widget-view.js
+++ b/js/src/dashboard-widget-view.js
@@ -53,7 +53,21 @@
 				self.$el.append( previewTemplate( { model: widgetModel, strings: strings }) );
 			} );
 			this.$el.append( addNewTemplate( { strings: strings } ) );
-		}
+		},
+
+		deleteWidget: function( $widgetView ) {
+			$widgetView.remove();
+			return false;
+		},
+
+		events: {
+			'click .submitdelete': function(e) {
+				var widget =  $( e.currentTarget ).closest( '.form-table' );
+				this.deleteWidget( widget );
+				return false;
+			}
+	},
+
 	} );
 
 	// Entry point: on load, render the Backbone view holding the form, using

--- a/js/src/dashboard-widget-view.js
+++ b/js/src/dashboard-widget-view.js
@@ -21,7 +21,7 @@
 		},
 
 		embedUrl: function embedUrl() {
-			var embedID = this.get('embedID');
+			var embedID = this.get( 'embedID' );
 			return embedID ? "https://insights-embed.newrelic.com/embedded_widget/" + embedID : "";
 		}
 	});
@@ -44,14 +44,15 @@
 
 		render: function() {
 			var previewTemplate = _.template( $( "#view-dashboard-widget" ).html() ),
-				addNewTemplate  = _.template( $( "#add-edit-dashboard-widget" ).html() ),
-                strings         = this.strings,
-                self            = this;
+			    addNewTemplate  = _.template( $( "#add-edit-dashboard-widget" ).html() ),
+			    strings         = this.strings,
+			    self            = this;
 
 			_.each( self.widgets, function( widget ) {
 				var widgetModel = new DashboardWidgetModel( widget );
 				self.$el.append( previewTemplate( { model: widgetModel, strings: strings }) );
 			} );
+
 			this.$el.append( addNewTemplate( { strings: strings } ) );
 		},
 

--- a/js/src/dashboard-widget-view.js
+++ b/js/src/dashboard-widget-view.js
@@ -1,0 +1,70 @@
+/**
+ * WP New Relic
+ * http://wordpress.org/plugins
+ *
+ * Copyright (c) 2017 10up
+ * Licensed under the GPLv2+ license.
+ */
+
+( function( window, $, _, Backbone, undefined ) {
+	'use strict';
+
+	/*
+	 * Representation of the settings for a single dashboard widget
+	 *
+	 */
+	var DashboardWidgetModel = Backbone.Model.extend({
+		defaults: {
+			title: '',
+			embedID: '',
+			description: '',
+		},
+
+		embedUrl: function embedUrl() {
+			var embedID = this.get('embedID');
+			return embedID ? "https://insights-embed.newrelic.com/embedded_widget/" + embedID : "";
+		}
+	});
+
+	/*
+	 * Backbone view controlling the form for deleting and adding dashboard widgets
+	 *
+	 */
+	var DashboardWidgetTable = Backbone.View.extend({
+
+		widgets: {},
+
+		i18n: {},
+
+		initialize: function() {
+			this.widgets = WP_NewRelic.dashboardWidgets;
+			this.i18n = WP_NewRelic.i18n;
+			this.render();
+		},
+
+		render: function() {
+			var previewTemplate = _.template( $( "#view-dashboard-widget" ).html() ),
+				addNewTemplate = _.template( $( "#add-edit-dashboard-widget" ).html() );
+
+			var self = this;
+			_.each( self.widgets, function( widget ) {
+				var widgetModel = new DashboardWidgetModel( widget );
+				self.$el.append( previewTemplate( { model: widgetModel }) );
+			} );
+			this.$el.append( addNewTemplate( ) );
+		}
+	} );
+
+	// Entry point: on load, render the Backbone view holding the form, using
+	// the settings data and translation strings passed in through localization variables.
+	document.addEventListener( 'DOMContentLoaded', function() {
+		var dashboard_widget = document.getElementById( 'wp-nr-widget-settings-form' );
+
+		if ( ! dashboard_widget ) {
+			return;
+		}
+
+		new DashboardWidgetTable( { el: $( dashboard_widget ) } );
+	} );
+
+} )( this, jQuery, _, Backbone );

--- a/js/src/dashboard-widget-view.js
+++ b/js/src/dashboard-widget-view.js
@@ -48,9 +48,9 @@
 			    strings         = this.strings,
 			    self            = this;
 
-			_.each( self.widgets, function( widget ) {
+			_.each( self.widgets, function( widget, i ) {
 				var widgetModel = new DashboardWidgetModel( widget );
-				self.$el.append( previewTemplate( { model: widgetModel, strings: strings }) );
+				self.$el.append( previewTemplate( { i: i, model: widgetModel, strings: strings }) );
 			} );
 
 			this.$el.append( addNewTemplate( { strings: strings } ) );

--- a/js/src/dashboard-widget-view.js
+++ b/js/src/dashboard-widget-view.js
@@ -38,20 +38,21 @@
 
 		initialize: function() {
 			this.widgets = WP_NewRelic.dashboardWidgets;
-			this.i18n = WP_NewRelic.i18n;
+			this.strings = WP_NewRelic.strings;
 			this.render();
 		},
 
 		render: function() {
 			var previewTemplate = _.template( $( "#view-dashboard-widget" ).html() ),
-				addNewTemplate = _.template( $( "#add-edit-dashboard-widget" ).html() );
+				addNewTemplate  = _.template( $( "#add-edit-dashboard-widget" ).html() ),
+                strings         = this.strings,
+                self            = this;
 
-			var self = this;
 			_.each( self.widgets, function( widget ) {
 				var widgetModel = new DashboardWidgetModel( widget );
-				self.$el.append( previewTemplate( { model: widgetModel }) );
+				self.$el.append( previewTemplate( { model: widgetModel, strings: strings }) );
 			} );
-			this.$el.append( addNewTemplate( ) );
+			this.$el.append( addNewTemplate( { strings: strings } ) );
 		}
 	} );
 

--- a/templates/add-new-dashboard-widget.html
+++ b/templates/add-new-dashboard-widget.html
@@ -1,0 +1,17 @@
+<script type="text/template" id="add-edit-dashboard-widget">
+	<h3 class="sub-title"><?php esc_html_e( 'Add new dashboard widget:', 'wp_newrelic' ); ?></h3>
+	<table class="form-table">
+		<tr>
+			<th scope="row"><label for=""><?php esc_html_e( 'Title', 'wp-newrelic' ); ?></label></th>
+			<td><input class="widefat" type="text" name="wp_nr_add_dashboard_widget[title]" /></td>
+		</tr>
+		<tr>
+			<th scope="row"><label for=""><?php esc_html_e( 'Embed HTML', 'wp-newrelic' ); ?></label></th>
+			<td><textarea class="widefat" type="text" name="wp_nr_add_dashboard_widget[embed_html]" /></textarea></td>
+		</tr>
+		<tr>
+			<th scope="row"><label for=""><?php esc_html_e( 'Embed Description', 'wp-newrelic' ); ?></label></th>
+			<td><textarea class="widefat" type="text" name="wp_nr_add_dashboard_widget[description]" /></textarea></td>
+		</tr>
+	</table>
+</script>

--- a/templates/view-dashboard-widget.html
+++ b/templates/view-dashboard-widget.html
@@ -3,13 +3,15 @@
 		<tr class="nr-dashboard-widget-row">
 			<th scope="row">
 				<label><%= model.get('title') %></label>
-				<a class="submitdelete" href=""><?php esc_html_e( 'Delete', 'wp-newrelic' ) ?></a>
+				<p class="actions">
+					<a class="submitdelete" href=""><%= strings.delete %></a>
+				</p>
 			</th>
-			<td style="max-width: 400px;">
+			<td style="display: block; max-height: 225px;">
 				<input type="hidden" name="wp_nr_dashboard_widgets[][title]" value="<%= model.get('title') %>" />
 				<input type="hidden" name="wp_nr_dashboard_widgets[][embedID]" value="<%= model.get('embedID') %>" />
 				<input type="hidden" name="wp_nr_dashboard_widgets[][description]" value="<%= model.get('description') %>" />
-				<div style="position: relative; width: 400px; max-width: 100%; height: 0; max-height: 225px; padding-top: 56.25%;">
+				<div style="position: relative; width: 400px; max-width: 100%; height: 0; padding-top: 56.25%;">
 					<iframe src="<% print( model.embedUrl() ) %>"
 						style="position: absolute; top: 0; left: 0; width: 100%; max-width: 400px; height: 100%; max-height: 225px;"
 						frameborder="0"></iframe>

--- a/templates/view-dashboard-widget.html
+++ b/templates/view-dashboard-widget.html
@@ -1,0 +1,20 @@
+<script type="text/template" id="view-dashboard-widget">
+	<table class="form-table">
+		<tr class="nr-dashboard-widget-row">
+			<th scope="row">
+				<label><%= model.get('title') %></label>
+				<a class="submitdelete" href=""><?php esc_html_e( 'Delete', 'wp-newrelic' ) ?></a>
+			</th>
+			<td style="max-width: 400px;">
+				<input type="hidden" name="wp_nr_dashboard_widgets[][title]" value="<%= model.get('title') %>" />
+				<input type="hidden" name="wp_nr_dashboard_widgets[][embedID]" value="<%= model.get('embedID') %>" />
+				<input type="hidden" name="wp_nr_dashboard_widgets[][description]" value="<%= model.get('description') %>" />
+				<div style="position: relative; width: 400px; max-width: 100%; height: 0; max-height: 225px; padding-top: 56.25%;">
+					<iframe src="<% print( model.embedUrl() ) %>"
+						style="position: absolute; top: 0; left: 0; width: 100%; max-width: 400px; height: 100%; max-height: 225px;"
+						frameborder="0"></iframe>
+				</div>
+			</td>
+		</tr>
+	</table>
+</script>

--- a/templates/view-dashboard-widget.html
+++ b/templates/view-dashboard-widget.html
@@ -2,15 +2,24 @@
 	<table class="form-table">
 		<tr class="nr-dashboard-widget-row">
 			<th scope="row">
-				<label><%= model.get('title') %></label>
+				<label>
+					<% if ( title = model.get('title') ) { %>
+						<%= model.get('title') %>
+					<% } else { %>
+						<%= strings.visualizationTitle %>
+					<% } %>
+				</label>
+				<% if ( description = model.get('description') ) { %>
+					<p class="description"><%= description %></p>
+				<% } %>
 				<p class="actions">
 					<a class="submitdelete" href=""><%= strings.delete %></a>
 				</p>
 			</th>
 			<td style="display: block; max-height: 225px;">
-				<input type="hidden" name="wp_nr_dashboard_widgets[][title]" value="<%= model.get('title') %>" />
-				<input type="hidden" name="wp_nr_dashboard_widgets[][embedID]" value="<%= model.get('embedID') %>" />
-				<input type="hidden" name="wp_nr_dashboard_widgets[][description]" value="<%= model.get('description') %>" />
+				<input type="hidden" name="wp_nr_dashboard_widgets[<%= i %>][title]" value="<%= model.get('title') %>" />
+				<input type="hidden" name="wp_nr_dashboard_widgets[<%= i %>][embedID]" value="<%= model.get('embedID') %>" />
+				<input type="hidden" name="wp_nr_dashboard_widgets[<%= i %>][description]" value="<%= model.get('description') %>" />
 				<div style="position: relative; width: 400px; max-width: 100%; height: 0; padding-top: 56.25%;">
 					<iframe src="<% print( model.embedUrl() ) %>"
 						style="position: absolute; top: 0; left: 0; width: 100%; max-width: 400px; height: 100%; max-height: 225px;"


### PR DESCRIPTION
Adds some very rough UI on the Tools > New Relic admin screen to add and remove desktop widgets by pasting in the embed HTML and specifying a title and description for the widget.

Still work in progress; needs some sanitization and a better way of specifying the position and size to use for the view embedded in the dashboard widget (the 16:9 crop that New relic defaults to for embeds tends to cut off the charts, and it would be nice to set a width for these widgets more explicitly than relying on WP's breakpoints for sortables.) 