### PR TITLE
Remove the option for disabling NREUM on AMP pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ After activating the plugin, You will see a new option named __New Relic__ under
 
 If the __Capture URLs__ setting is enabled, the plugin will capture URL parameters for displaying in Transaction traces. As an example, turning on this feature will store a URL like http://example.com/?p=1234, while leaving it off will result in the URL being stored as http://example.com/. This feature can be useful for debugging or providing granular data if required. In certain cases, however, it can cause confusion by creating a "false positive" appearance of multiple URLs (e.g. UTM codes or tracking info from social media).
 
-### Disable for AMP
-
-If the __Disable for AMP__ setting is enabled, it will disable New Relic for AMP endpoints.
-
 ## Basic Config
 
 By default the plugin will setup 3 New Relic configuration parameters:
@@ -33,7 +29,7 @@ Certain useful custom attributes (you can think of these as 'post meta for New R
 
 ### User
 
-The user attribute is set using [newrelic_set_user_attributes](https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-api#api-set-user-attributes). If the user is logged in, the user ID will be set as the user attribute and if not the user attribute will be set to `not-logged-in`.  
+The user attribute is set using [newrelic_set_user_attributes](https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-api#api-set-user-attributes). If the user is logged in, the user ID will be set as the user attribute and if not the user attribute will be set to `not-logged-in`.
 Ex: In New Relic Insights you can query Transactions for non-logged in users as
 ```
 SELECT * FROM Transaction WHERE appName = '{appName}' AND user = 'not-logged-in'
@@ -41,7 +37,7 @@ SELECT * FROM Transaction WHERE appName = '{appName}' AND user = 'not-logged-in'
 
 ### Post ID
 For single posts, the post ID will be set via the `post_id` custom attribute.
-  
+
 Ex: Get all Transactions for a post with ID 190.
 ```
 SELECT * FROM Transaction WHERE appName = '{appName}' AND post_id = '190'
@@ -82,12 +78,12 @@ SELECT * FROM Transaction WHERE appName = '{appName}' AND request_type = 'ajax'
 
 ### Transaction Name
 
-The Transaction name is set based on the main WP_Query parameters using [newrelic_name_transaction](https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-api#api-name-wt). 
+The Transaction name is set based on the main WP_Query parameters using [newrelic_name_transaction](https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-api#api-name-wt).
 Possible values are Default Home Page, Front Page, Blog Page, Network Dashboard, Dashboard, Single - {post_type}, Page - {pagename}, Date Archive, Search Page, Feed, Archive - {post_type}, Category - {cat_name}, Tag - {tag_name}, Tax - {taxonomy} - {term}
 
 ### Custom Error Logging
 
-Using the __wp_nr_log_errors__ function, any plugin/theme can log errors/notices to New Relic for the current Transaction. 
+Using the __wp_nr_log_errors__ function, any plugin/theme can log errors/notices to New Relic for the current Transaction.
 Note: This function can be called more than once, but only the last call will log the error to New Relic. This is a known limitation of the [PHP Agent API](https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-api#api-notice-error). As a reminder, since the PHP Agent runs only when PHP does, any cached requests will not appear in your error logs.
 
 ```
@@ -121,7 +117,7 @@ The WP New Relic plugin is developed and maintained by 10up, Inc.
 
 ### License
 
-The WP New Relic plugin is released under the [GNU Public License v2](http://www.gnu.org/licenses/gpl-2.0.html) or later. 
+The WP New Relic plugin is released under the [GNU Public License v2](http://www.gnu.org/licenses/gpl-2.0.html) or later.
 
 ### Issues
 

--- a/classes/class-wp-nr-apm.php
+++ b/classes/class-wp-nr-apm.php
@@ -24,9 +24,7 @@ class WP_NR_APM {
 		add_action( 'wp_async_task_before_job', array( $this, 'async_before_job_track_time' ), 9999, 1 );
 		add_action( 'wp_async_task_after_job', array( $this, 'async_after_job_set_attribute' ), 9999, 1 );
 
-		if ( WP_NR_Helper::is_disable_amp() ) {
-			add_action( 'pre_amp_render_post', array( $this, 'disable_nr_autorum' ), 9999, 1 );
-		}
+		add_action( 'pre_amp_render_post', array( $this, 'disable_nr_autorum' ), 9999, 1 );
 	}
 
 	/**

--- a/classes/class-wp-nr-dashboard.php
+++ b/classes/class-wp-nr-dashboard.php
@@ -28,7 +28,6 @@ class WP_NR_Dashboard {
 
 		if ( wp_verify_nonce( $nonce, 'wp_nr_settings' ) ) {
 			$capture_url = filter_input( INPUT_POST, 'wp_nr_capture_urls' );
-			$disable_amp = filter_input( INPUT_POST, 'wp_nr_disable_amp' );
 
 			if ( ! empty( $capture_url ) ) {
 				$capture_url = true;
@@ -36,18 +35,10 @@ class WP_NR_Dashboard {
 				$capture_url = false;
 			}
 
-			if ( ! empty( $disable_amp ) ) {
-				$disable_amp = true;
-			} else {
-				$disable_amp = false;
-			}
-
 			if ( WP_NR_IS_NETWORK_ACTIVE ) {
 				update_site_option( 'wp_nr_capture_urls', $capture_url );
-				update_site_option( 'wp_nr_disable_amp', $disable_amp );
 			} else {
 				update_option( 'wp_nr_capture_urls', $capture_url );
-				update_option( 'wp_nr_disable_amp', $disable_amp );
 			}
 		}
 	}
@@ -82,7 +73,6 @@ class WP_NR_Dashboard {
 	 */
 	public function dashboard_page() {
 		$is_capture = WP_NR_Helper::is_capture_url();
-		$is_disable_amp = WP_NR_Helper::is_disable_amp();
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'New Relic for WordPress', 'wp-newrelic' ) ?></h1>
@@ -96,13 +86,6 @@ class WP_NR_Dashboard {
 						<td>
 							<input type="checkbox" name="wp_nr_capture_urls" <?php checked( true, $is_capture ) ?>>
 							<p class="description"><?php esc_html_e( 'Enable this to record parameter passed to PHP script via the URL (everything after the "?" in the URL).', 'wp-newrelic' ) ?></p>
-						</td>
-					</tr>
-					<tr>
-						<th scope="row"><label for="wp_nr_disable_amp"><?php esc_html_e( 'Disable for AMP', 'wp-newrelic' ); ?></label></th>
-						<td>
-							<input type="checkbox" name="wp_nr_disable_amp" <?php checked( true, $is_disable_amp ) ?>>
-							<p class="description"><?php esc_html_e( 'Enable this to disable New Relic for AMP.', 'wp-newrelic' ) ?></p>
 						</td>
 					</tr>
 				</table>

--- a/classes/class-wp-nr-helper.php
+++ b/classes/class-wp-nr-helper.php
@@ -13,17 +13,7 @@ class WP_NR_Helper {
 	 * @return bool
 	 */
 	public static function is_capture_url() {
-
 		return self::get_setting( 'wp_nr_capture_urls' );
-	}
-
-	/**
-	 * Check if disable for AMP setting is enabled or not
-	 *
-	 * @return bool
-	 */
-	public static function is_disable_amp() {
-		return self::get_setting( 'wp_nr_disable_amp' );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -21,8 +21,6 @@ After activating the plugin, You will see a new option named __New Relic__ under
 
 Capture URL Parameters: If Capture URLs setting is enabled, it will capture URL parameters for displaying in transaction traces.
 
-Disable for AMP: If Disable for AMP setting is enabled, it will disable New Relic for AMP endpoints.
-
 = Basic Config =
 
 By default plugin will setup 3 configs.


### PR DESCRIPTION
There's no context where you would want to include New Relic scripts in
AMP pages, so it doesn't make sense to expose this as an option. This
removes the option, and just hooks `disable_nr_autorum()` onto the
`pre_amp_render_post` action, so that any pages which are served through
the AMP plugin will not include the browser monitoring instrument
script.