### PR TITLE
PHP Error When Viewing Pages

### DIFF
--- a/classes/class-wp-nr-apm.php
+++ b/classes/class-wp-nr-apm.php
@@ -135,7 +135,7 @@ class WP_NR_APM {
 				$transaction = "Single - {$post_type}";
 			} elseif ( is_page() ) {
 				if ( isset( $query->query['pagename'] ) ) {
-					$this->add_custom_parameter( $query->query['pagename'] );
+					$this->add_custom_parameter( 'page', $query->query['pagename'] );
 				}
 				$transaction = "Page";
 			} elseif ( is_date() ) {


### PR DESCRIPTION
The add_custom_parameter method expects two arguments, these are not set when viewing pages and result in a PHP error.