### PR TITLE
Fix warnings if $template variable type has been changed.

### DIFF
--- a/classes/class-wp-nr-apm.php
+++ b/classes/class-wp-nr-apm.php
@@ -57,7 +57,11 @@ class WP_NR_APM {
 	 * @return mixed
 	 */
 	public function set_template( $template ) {
-		if ( function_exists( 'newrelic_add_custom_parameter' ) ) {
+		if ( ! is_string( $template ) && function_exists( 'add_custom_parameter' ) ) {
+			add_custom_parameter( 'template_warning', sprintf( '$template has been converted from a string to a %s by another plugin.', gettype( $template ) ) );
+		}
+
+		if ( is_string( $template ) && function_exists( 'newrelic_add_custom_parameter' ) ) {
 			newrelic_add_custom_parameter( 'template', $template );
 		}
 


### PR DESCRIPTION
In #17 the issue is that a plugin is converting the `$template` string to an object. Throwing an error when newrelic's add param function expects a string.

This makes sure that `$template` is a string before trying to add the param. It also adds a warning param if `$template` isn't a string, so that the user can start debugging.