### PR TITLE
Handle REST Calls

### DIFF
--- a/classes/class-wp-nr-apm.php
+++ b/classes/class-wp-nr-apm.php
@@ -28,6 +28,7 @@ class WP_NR_APM {
 			add_action( 'admin_init', array( $this, 'set_admin_transaction' ) );
 		} else {
 			add_action( 'wp', array( $this, 'set_wp_transaction' ) );
+			add_action( 'rest_api_init', array( $this, 'set_wp_transaction' ) );
 		}
 	}
 


### PR DESCRIPTION
Since the `wp` hook isn't triggered on REST API filters, add the `rest_api_init` action for handling the REST API right into New Relic