### PR TITLE
Do not remove user role value from roles property.

### DIFF
--- a/classes/class-wp-nr-apm.php
+++ b/classes/class-wp-nr-apm.php
@@ -85,7 +85,7 @@ class WP_NR_APM {
 		if ( function_exists( 'newrelic_set_user_attributes' ) ) {
 			if ( is_user_logged_in() ) {
 				$user = wp_get_current_user();
-				newrelic_set_user_attributes( $user->ID, '', array_shift( $user->roles ) );
+				newrelic_set_user_attributes( $user->ID, '', reset( $user->roles ) );
 			} else {
 				newrelic_set_user_attributes( 'not-logged-in', '', 'no-role' );
 			}


### PR DESCRIPTION
Hi @allan23 , could you please review this PR which addresses #25 ?

It seems that by using `array_shift()` to retrieve the first element of the roles property, we are taking away this value, so the property ends up empty and it causes the user to not have any roles.

There were many alternatives to `array_shift()` like` current() `but i prefered to use `reset()` since it retrieves the first element of the property. I'm not sure if `array_shift()` was deliberately used here with another purpose in mind than just retrieving a value, so I might be missing something.

Thanks.