### PR TITLE
Check if we have the main query defined, and then check the var

### DIFF
--- a/classes/class-wp-nr-apm.php
+++ b/classes/class-wp-nr-apm.php
@@ -203,7 +203,7 @@ class WP_NR_APM {
 			return;
 		}
 
-		if ( get_query_var( 'sitemap', false ) ) {
+		if ( $query->is_main_query() && $query->get( 'sitemap', false ) ) {
 			newrelic_name_transaction( 'Sitemap' );
 		}
 	}


### PR DESCRIPTION
### Description of the Change

We've found that in some cases, the sitemap check fails if the global wp_query is not defined at the moment, since pre_get_posts can be used for a query that's executed before the main query. I'm changing the function used.

### Alternate Designs

Not applicable. Just fixed an issue I found.

### Benefits

Fatal errors not triggered.

### Possible Drawbacks

There shouldn't be any.

### Verification Process

Did this change, and the fatal was fixed.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.