### PR TITLE
Add PHP version notice to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 [![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/wp-newrelic.svg)](https://github.com/10up/wp-newrelic/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.3%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/wp-newrelic.svg)](https://github.com/10up/wp-newrelic/blob/develop/LICENSE.md)
 
+## Table of Contents
+
+* [Overview](#overview)
+* [Administrative Settings](#administrative-settings)
+* [Basic Config](#basic-config)
+* [New Relic Custom Attributes](#new-relic-custom-attributes)
+* [Screenshots](#screenshots)
+* [Known Issues](#known-issuescaveats)
+* [Support](#support-level)
+
+## Overview
+
 WP New Relic (WPNR) is designed to be used with the [New Relic APM](https://newrelic.com/application-monitoring), and uses the [New Relic PHP Agent API](https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-api) to augment existing metrics with valuable WordPress details such as templates, users, request type, and [Transaction](https://docs.newrelic.com/docs/apm/transactions) names. This plugin is tested with New Relic's PHP Agent version 6.7.0.174. Data collected by this plugin can be queried in [New Relic's Insights](https://newrelic.com/insights/) product, using [New Relic Query Language (NRQL)](https://docs.newrelic.com/docs/insights/new-relic-insights/using-new-relic-query-language/nrql-reference).
 
 New Relic is a trademark of New Relic, Inc.
@@ -40,6 +52,7 @@ SELECT * FROM Transaction WHERE appName = '{appName}' AND user = 'not-logged-in'
 ```
 
 ### Post ID
+
 For single posts, the post ID will be set via the `post_id` custom attribute.
 
 Ex: Get all Transactions for a post with ID 190.
@@ -112,7 +125,13 @@ This plugin also tracks the runtime of [gearman](https://github.com/10up/WP-Gear
 ![wp-nr-databaseduration-query](https://cloud.githubusercontent.com/assets/2941333/20933427/ffb5652a-bbfd-11e6-97fa-ca68d66c579d.png)
 (Get Template used and Transactions whose database duration is more than 0.1)
 
-### Issues
+## Known Issues/Caveats
+
+### PHP version
+
+PHP version 7.3.3 is known to cause issues with this plugin, updating to 7.3.11 or greater appears to resolve these issues.  For more details, see [issue#39](https://github.com/10up/wp-newrelic/issues/39).
+
+### Have an issue to report?
 
 If you identify any errors or have an idea for improving the plugin, please open an [issue](https://github.com/10up/wp-newrelic/issues?stage=open). We're excited to see what the community thinks of this project, and we would love your input!
 

--- a/readme.txt
+++ b/readme.txt
@@ -82,7 +82,6 @@ Certain useful custom attrribute (just like WordPress post meta) will be set for
     Transaction name is getting set as per the main WP_Query parameters using [newrelic_name_transaction](https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-api#api-name-wt).
     Possible values are Default Home Page, Front Page, Blog Page, Network Dashboard, Dashboard, Single - {post_type}, Page - {pagename}, Date Archive, Search Page, Feed, Archive - {post_type}, Category - {cat_name}, Tag - {tag_name}, Tax - {taxonomy} - {term}
 
-
 7. __Custom Error Logging__
 
     Using __wp_nr_log_errors__ function, any plugin/theme can log errors/notices to New Relic for current transaction.
@@ -96,6 +95,10 @@ Certain useful custom attrribute (just like WordPress post meta) will be set for
 
 = Issues =
 
+1. __PHP version__
+PHP version 7.3.3 is known to cause issues with this plugin, updating to 7.3.11 or greater appears to resolve these issues.  For more details, see [issue#39](https://github.com/10up/wp-newrelic/issues/39).
+
+2. __Have an issue to report?__
 If you identify any errors or have an idea for improving the plugin, please open an [issue](https://github.com/10up/wp-newrelic/issues?stage=open). We're excited to see what the community thinks of this project, and we would love your input!
 
 == Installation ==


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR adds a note to the README.md and readme.txt files about the recently reported PHP 7.3.3 version incompatibility issue and note to update to PHP 7.3.11+.

### Alternate Designs

n/a

### Benefits

Ensures that customers are aware of potential PHP version conflicts.

### Possible Drawbacks

None identified

### Verification Process

Manually verified via the GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
Resolves #39 

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
n/a