### PR TITLE
Fix/56 PHP Version Check

### DIFF
--- a/newrelic-reporting-for-wordpress.php
+++ b/newrelic-reporting-for-wordpress.php
@@ -31,6 +31,49 @@ if ( ! defined( 'WP_NR_BASENAME' ) ) {
 }
 
 /**
+ * Get the minimum version of PHP required by this plugin.
+ *
+ * @return string Minimum version required.
+ */
+function wp_nr_minimum_php_requirement() {
+	return '7.3.11';
+}
+
+/**
+ * Checks whether PHP installation meets the minimum requirements
+ *
+ * @return bool True if meets minimum requirements, false otherwise.
+ */
+function wp_nr_site_meets_php_requirements() {
+
+	return version_compare( phpversion(), wp_nr_minimum_php_requirement(), '>=' );
+}
+
+if ( ! wp_nr_site_meets_php_requirements() ) {
+	add_action(
+		'admin_notices',
+		function() {
+			?>
+			<div class="notice notice-error">
+				<p>
+					<?php
+					echo wp_kses_post(
+						sprintf(
+							/* translators: %s: Minimum required PHP version */
+							__( 'New Relic Reporting for WordPress requires PHP version %s or later. Please upgrade PHP or disable the plugin.', 'wp-newrelic' ),
+							esc_html( wp_nr_minimum_php_requirement() )
+						)
+					);
+					?>
+				</p>
+			</div>
+			<?php
+		}
+	);
+	return;
+}
+
+/**
  * Check if plugin is network active.
  *
  * @return bool


### PR DESCRIPTION
### Description of the Change

Added a minimum PHP version check for 7.3.11.

Closes #56 

### How to test the Change

1. Spin up the site with a version of PHP below 7.3.11
2. Verify an admin notice has been added alerting the user of the failed check

### Changelog Entry

> Added - >=PHP 7.3.11 version check

### Credits

Props @bmarshall511 


### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
