### PR TITLE
Fix: deprecated FILTER_SANITIZE_STRING warning

### DIFF
--- a/classes/class-wp-nr-dashboard.php
+++ b/classes/class-wp-nr-dashboard.php
@@ -24,7 +24,7 @@ class WP_NR_Dashboard {
 	 * Save settings
 	 */
 	public function save_settings() {
-		$nonce = filter_input( INPUT_POST, 'wp_nr_settings', FILTER_SANITIZE_STRING );
+		$nonce = filter_input( INPUT_POST, 'wp_nr_settings', FILTER_SANITIZE_SPECIAL_CHARS );
 
 		if ( wp_verify_nonce( $nonce, 'wp_nr_settings' ) ) {
 			$capture_url = filter_input( INPUT_POST, 'wp_nr_capture_urls' );
@@ -75,7 +75,7 @@ class WP_NR_Dashboard {
 		$is_capture = WP_NR_Helper::is_capture_url();
 		?>
 		<div class="wrap">
-			<h1><?php esc_html_e( 'New Relic for WordPress', 'wp-newrelic' ) ?></h1>
+			<h1><?php esc_html_e( 'New Relic for WordPress', 'wp-newrelic' ); ?></h1>
 			<form method="post" action="">
 				<?php
 				wp_nonce_field( 'wp_nr_settings', 'wp_nr_settings' );
@@ -84,8 +84,8 @@ class WP_NR_Dashboard {
 					<tr>
 						<th scope="row"><label for="wp_nr_capture_urls"><?php esc_html_e( 'Capture URL Parameters', 'wp-newrelic' ); ?></label></th>
 						<td>
-							<input type="checkbox" name="wp_nr_capture_urls" <?php checked( true, $is_capture ) ?>>
-							<p class="description"><?php esc_html_e( 'Enable this to record parameter passed to PHP script via the URL (everything after the "?" in the URL).', 'wp-newrelic' ) ?></p>
+							<input type="checkbox" name="wp_nr_capture_urls" <?php checked( true, $is_capture ); ?>>
+							<p class="description"><?php esc_html_e( 'Enable this to record parameter passed to PHP script via the URL (everything after the "?" in the URL).', 'wp-newrelic' ); ?></p>
 						</td>
 					</tr>
 				</table>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the plugin throws a deprecated FILTER_SANITIZE_STRING warning.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #67

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Improve compatibility with PHP 8.1 by replacing the deprecated FILTER_SANITIZE_STRING



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @jeffpaul 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
