### PR TITLE
WordPress Playground integration

### DIFF
--- a/.github/blueprints/blueprint.json
+++ b/.github/blueprints/blueprint.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
-	"landingPage": "/wp-admin",
+	"landingPage": "/wp-admin/plugins.php",
 	"preferredVersions": {
 		"php": "8.0",
 		"wp": "latest"

--- a/.github/blueprints/blueprint.json
+++ b/.github/blueprints/blueprint.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin",
+	"preferredVersions": {
+		"php": "8.0",
+		"wp": "latest"
+	},
+	"features": {
+		"networking": true
+	},
+	"steps": [
+		{
+			"step": "installPlugin",
+			"pluginZipFile": {
+				"resource": "wordpress.org/plugins",
+				"slug": "wp-newrelic"
+			},
+			"options": {
+				"activate": true
+			}
+		}
+	]
+}

--- a/.github/blueprints/blueprint.json
+++ b/.github/blueprints/blueprint.json
@@ -10,6 +10,13 @@
 	},
 	"steps": [
 		{
+			"step": "setSiteOptions",
+			"options": {
+				"blogname": "New Relic Reporting for WordPress Playground",
+				"blogdescription": "Trying out New Relic Reporting for WordPress."
+			}
+		},
+		{
 			"step": "installPlugin",
 			"pluginZipFile": {
 				"resource": "wordpress.org/plugins",
@@ -17,6 +24,15 @@
 			},
 			"options": {
 				"activate": true
+			},
+			"progress": {
+				"caption": "Installing plugin New Relic Reporting for WordPress by 10up"
+			}
+		},
+		{
+			"step": "defineWpConfigConsts",
+			"consts": {
+				"IS_WP_PLAYGROUND": true
 			}
 		}
 	]

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ https://playground.wordpress.net/?plugin=wp-newrelic
 ```
 
 **Using Blueprint:**
-A blueprint file is included at `.wordpress-org/blueprints/blueprint.json` that automatically installs and activates the plugin. You can use this blueprint URL:
+A blueprint file is included at `.github/blueprints/blueprint.json` that automatically installs and activates the plugin. You can use this blueprint URL:
 ```
-https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/10up/wp-newrelic/develop/.wordpress-org/blueprints/blueprint.json
+https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/10up/wp-newrelic/develop/.github/blueprints/blueprint.json
 ```
 
 ### Important Notes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![WP New Relic](https://github.com/10up/wp-newrelic/blob/develop/.wordpress-org/banner-1544x500.png)
 
-[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) ![Required PHP Version](https://img.shields.io/wordpress/plugin/required-php/wp-newrelic?label=Requires%20PHP) ![Required WP Version](https://img.shields.io/wordpress/plugin/wp-version/wp-newrelic?label=Requires%20WordPress) [![Release Version](https://img.shields.io/github/release/10up/wp-newrelic.svg)](https://github.com/10up/wp-newrelic/releases/latest) ![WordPress tested up to version](https://img.shields.io/wordpress/plugin/tested/wp-newrelic?label=WordPress) [![GPL-2.0-or-later License](https://img.shields.io/github/license/10up/wp-newrelic.svg)](https://github.com/10up/wp-newrelic/blob/develop/LICENSE.md) [![Dependency Review](https://github.com/10up/wp-newrelic/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/wp-newrelic/actions/workflows/dependency-review.yml) [![E2E Tests](https://github.com/10up/wp-newrelic/actions/workflows/cypress.yml/badge.svg)](https://github.com/10up/wp-newrelic/actions/workflows/cypress.yml)
+[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) ![Required PHP Version](https://img.shields.io/wordpress/plugin/required-php/wp-newrelic?label=Requires%20PHP) ![Required WP Version](https://img.shields.io/wordpress/plugin/wp-version/wp-newrelic?label=Requires%20WordPress) [![Release Version](https://img.shields.io/github/release/10up/wp-newrelic.svg)](https://github.com/10up/wp-newrelic/releases/latest) ![WordPress tested up to version](https://img.shields.io/wordpress/plugin/tested/wp-newrelic?label=WordPress) [![GPL-2.0-or-later License](https://img.shields.io/github/license/10up/wp-newrelic.svg)](https://github.com/10up/wp-newrelic/blob/develop/LICENSE.md) [![Dependency Review](https://github.com/10up/wp-newrelic/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/wp-newrelic/actions/workflows/dependency-review.yml) [![E2E Tests](https://github.com/10up/wp-newrelic/actions/workflows/cypress.yml/badge.svg)](https://github.com/10up/wp-newrelic/actions/workflows/cypress.yml) [![WordPress Playground Demo](https://img.shields.io/wordpress/plugin/v/wp-newrelic?logo=wordpress&logoColor=FFFFFF&label=Playground%20Demo&labelColor=3858E9&color=3858E9)](https://playground.wordpress.net/?plugin=wp-newrelic)
 
 > New Relic APM reports for WordPress.
 
@@ -116,6 +116,31 @@ This plugin also tracks the runtime of [gearman](https://github.com/10up/WP-Gear
 
 ![wp-nr-databaseduration-query](https://cloud.githubusercontent.com/assets/2941333/20933427/ffb5652a-bbfd-11e6-97fa-ca68d66c579d.png)
 (Get Template used and Transactions whose database duration is more than 0.1)
+
+## WordPress Playground Integration
+
+This plugin includes integration with [WordPress Playground](https://wordpress.github.io/wordpress-playground/), allowing you to test and demonstrate the plugin in a browser-based WordPress environment.
+
+### Try it in Playground
+
+You can launch WordPress Playground with this plugin pre-installed using one of these methods:
+
+**Direct URL:**
+```
+https://playground.wordpress.net/?plugin=wp-newrelic
+```
+
+**Using Blueprint:**
+A blueprint file is included at `.wordpress-org/blueprints/blueprint.json` that automatically installs and activates the plugin. You can use this blueprint URL:
+```
+https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/10up/wp-newrelic/develop/.wordpress-org/blueprints/blueprint.json
+```
+
+### Important Notes
+
+- **New Relic Extension Not Available**: WordPress Playground runs PHP in a browser environment using WebAssembly. The New Relic PHP extension is not available in this environment, so the plugin will display an informational notice explaining this limitation.
+- **For Testing Only**: Playground is ideal for testing plugin functionality, exploring settings, and demonstrating features. For production use, install the plugin on a server with the New Relic PHP agent installed.
+- **Environment Detection**: The plugin automatically detects when running in WordPress Playground and provides appropriate messaging. You can disable the Playground notice by defining `WP_NR_DISABLE_PLAYGROUND_NOTICE` as `true`.
 
 ## Known Issues/Caveats
 

--- a/classes/class-wp-nr.php
+++ b/classes/class-wp-nr.php
@@ -18,6 +18,11 @@ class WP_NR {
 				return;
 			}
 
+			// Skip notice in WordPress Playground if explicitly disabled
+			if ( self::is_playground() && defined( 'WP_NR_DISABLE_PLAYGROUND_NOTICE' ) && true === WP_NR_DISABLE_PLAYGROUND_NOTICE ) {
+				return;
+			}
+
 			if ( WP_NR_IS_NETWORK_ACTIVE ) {
 				add_action( 'network_admin_notices', array( $this, 'wp_nr_not_installed_notice' ) );
 			} else {
@@ -47,11 +52,51 @@ class WP_NR {
 	}
 
 	/**
+	 * Check if running in WordPress Playground environment
+	 *
+	 * @return bool True if running in WordPress Playground, false otherwise.
+	 */
+	public static function is_playground() {
+		// Check for WordPress Playground environment indicators
+		if ( defined( 'IS_WP_PLAYGROUND' ) && true === IS_WP_PLAYGROUND ) {
+			return true;
+		}
+
+		// Check if running in browser-based PHP environment (Playground uses WebAssembly)
+		if ( isset( $_SERVER['HTTP_HOST'] ) && str_contains( sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ), 'playground.wordpress.net' ) !== false ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Admin notice if New Relic extension is not loaded
 	 */
 	public function wp_nr_not_installed_notice() {
-		?>
-		<div class="error"><p><strong>WP New Relic: </strong><?php esc_html_e( 'New Relic is not installed.', 'wp-newrelic' ) ?></p></div>
-		<?php
+		$is_playground = self::is_playground();
+
+		if ( $is_playground ) {
+			?>
+			<div class="notice notice-info">
+				<p>
+					<strong><?php esc_html_e( 'WP New Relic: ', 'wp-newrelic' ); ?></strong>
+					<?php
+					echo wp_kses_post(
+						sprintf(
+							/* translators: %s: WordPress Playground documentation link */
+							__( 'You are running WordPress in Playground. The New Relic PHP extension is not available in this browser-based environment. This plugin is designed for production environments with the New Relic PHP agent installed. <a href="%s" target="_blank">Learn more about WordPress Playground</a>.', 'wp-newrelic' ),
+							esc_url( 'https://wordpress.github.io/wordpress-playground/' )
+						)
+					);
+					?>
+				</p>
+			</div>
+			<?php
+		} else {
+			?>
+			<div class="error"><p><strong><?php esc_html_e( 'WP New Relic:', 'wp-newrelic' ); ?> </strong><?php esc_html_e( 'New Relic is not installed.', 'wp-newrelic' ); ?></p></div>
+			<?php
+		}
 	}
 }

--- a/classes/class-wp-nr.php
+++ b/classes/class-wp-nr.php
@@ -18,6 +18,11 @@ class WP_NR {
 				return;
 			}
 
+			// Skip notice in WordPress Playground if explicitly disabled
+			if ( self::is_playground() && defined( 'WP_NR_DISABLE_PLAYGROUND_NOTICE' ) && true === WP_NR_DISABLE_PLAYGROUND_NOTICE ) {
+				return;
+			}
+
 			if ( WP_NR_IS_NETWORK_ACTIVE ) {
 				add_action( 'network_admin_notices', array( $this, 'wp_nr_not_installed_notice' ) );
 			} else {
@@ -47,11 +52,61 @@ class WP_NR {
 	}
 
 	/**
+	 * Check if running in WordPress Playground environment
+	 *
+	 * @return bool True if running in WordPress Playground, false otherwise.
+	 */
+	public static function is_playground() {
+		// Check for WordPress Playground environment indicators
+		if ( defined( 'WP_PLAYGROUND' ) && WP_PLAYGROUND ) {
+			return true;
+		}
+
+		// Check for Playground-specific constants or environment variables
+		if ( defined( 'PLAYGROUND_ENVIRONMENT' ) && PLAYGROUND_ENVIRONMENT ) {
+			return true;
+		}
+
+		// Check for Playground user agent or server variables
+		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && strpos( $_SERVER['HTTP_USER_AGENT'], 'WordPress-Playground' ) !== false ) {
+			return true;
+		}
+
+		// Check if running in browser-based PHP environment (Playground uses WebAssembly)
+		if ( isset( $_SERVER['HTTP_HOST'] ) && strpos( $_SERVER['HTTP_HOST'], 'playground.wordpress.net' ) !== false ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Admin notice if New Relic extension is not loaded
 	 */
 	public function wp_nr_not_installed_notice() {
-		?>
-		<div class="error"><p><strong>WP New Relic: </strong><?php esc_html_e( 'New Relic is not installed.', 'wp-newrelic' ) ?></p></div>
-		<?php
+		$is_playground = self::is_playground();
+
+		if ( $is_playground ) {
+			?>
+			<div class="notice notice-info">
+				<p>
+					<strong><?php esc_html_e( 'WP New Relic: ', 'wp-newrelic' ); ?></strong>
+					<?php
+					echo wp_kses_post(
+						sprintf(
+							/* translators: %s: WordPress Playground documentation link */
+							__( 'You are running WordPress in Playground. The New Relic PHP extension is not available in this browser-based environment. This plugin is designed for production environments with the New Relic PHP agent installed. <a href="%s" target="_blank">Learn more about WordPress Playground</a>.', 'wp-newrelic' ),
+							esc_url( 'https://wordpress.github.io/wordpress-playground/' )
+						)
+					);
+					?>
+				</p>
+			</div>
+			<?php
+		} else {
+			?>
+			<div class="error"><p><strong>WP New Relic: </strong><?php esc_html_e( 'New Relic is not installed.', 'wp-newrelic' ) ?></p></div>
+			<?php
+		}
 	}
 }

--- a/classes/class-wp-nr.php
+++ b/classes/class-wp-nr.php
@@ -18,11 +18,6 @@ class WP_NR {
 				return;
 			}
 
-			// Skip notice in WordPress Playground if explicitly disabled
-			if ( self::is_playground() && defined( 'WP_NR_DISABLE_PLAYGROUND_NOTICE' ) && true === WP_NR_DISABLE_PLAYGROUND_NOTICE ) {
-				return;
-			}
-
 			if ( WP_NR_IS_NETWORK_ACTIVE ) {
 				add_action( 'network_admin_notices', array( $this, 'wp_nr_not_installed_notice' ) );
 			} else {
@@ -52,61 +47,11 @@ class WP_NR {
 	}
 
 	/**
-	 * Check if running in WordPress Playground environment
-	 *
-	 * @return bool True if running in WordPress Playground, false otherwise.
-	 */
-	public static function is_playground() {
-		// Check for WordPress Playground environment indicators
-		if ( defined( 'WP_PLAYGROUND' ) && WP_PLAYGROUND ) {
-			return true;
-		}
-
-		// Check for Playground-specific constants or environment variables
-		if ( defined( 'PLAYGROUND_ENVIRONMENT' ) && PLAYGROUND_ENVIRONMENT ) {
-			return true;
-		}
-
-		// Check for Playground user agent or server variables
-		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && strpos( $_SERVER['HTTP_USER_AGENT'], 'WordPress-Playground' ) !== false ) {
-			return true;
-		}
-
-		// Check if running in browser-based PHP environment (Playground uses WebAssembly)
-		if ( isset( $_SERVER['HTTP_HOST'] ) && strpos( $_SERVER['HTTP_HOST'], 'playground.wordpress.net' ) !== false ) {
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
 	 * Admin notice if New Relic extension is not loaded
 	 */
 	public function wp_nr_not_installed_notice() {
-		$is_playground = self::is_playground();
-
-		if ( $is_playground ) {
-			?>
-			<div class="notice notice-info">
-				<p>
-					<strong><?php esc_html_e( 'WP New Relic: ', 'wp-newrelic' ); ?></strong>
-					<?php
-					echo wp_kses_post(
-						sprintf(
-							/* translators: %s: WordPress Playground documentation link */
-							__( 'You are running WordPress in Playground. The New Relic PHP extension is not available in this browser-based environment. This plugin is designed for production environments with the New Relic PHP agent installed. <a href="%s" target="_blank">Learn more about WordPress Playground</a>.', 'wp-newrelic' ),
-							esc_url( 'https://wordpress.github.io/wordpress-playground/' )
-						)
-					);
-					?>
-				</p>
-			</div>
-			<?php
-		} else {
-			?>
-			<div class="error"><p><strong>WP New Relic: </strong><?php esc_html_e( 'New Relic is not installed.', 'wp-newrelic' ) ?></p></div>
-			<?php
-		}
+		?>
+		<div class="error"><p><strong>WP New Relic: </strong><?php esc_html_e( 'New Relic is not installed.', 'wp-newrelic' ) ?></p></div>
+		<?php
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -94,6 +94,17 @@ Certain useful custom attrribute (just like WordPress post meta) will be set for
 
     This plugin also tracks runtime of [gearman](https://github.com/10up/WP-Gears) async tasks. Gearman async task run for a particular hook and it’s runtime can be track using “wp_async_task-{hook}” custom attribute in New Relic Insights.
 
+= WordPress Playground Integration =
+
+This plugin includes integration with WordPress Playground, allowing you to test and demonstrate the plugin in a browser-based WordPress environment.
+
+Try it in Playground:
+https://playground.wordpress.net/?plugin=wp-newrelic
+
+Important Notes:
+* The New Relic PHP extension is not available in WordPress Playground (browser-based environment), so the plugin will display an informational notice.
+* Playground is ideal for testing plugin functionality and exploring settings. For production use, install on a server with the New Relic PHP agent installed.
+
 = Issues =
 
 1. __PHP version__


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
WordPress Playground integration

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #74 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Load the WordPress Playground configuration from this PR [here](https://akirk.github.io/playground-step-library/?step[0]=installPlugin&url[0]=github.com/10up/wp-newrelic/pull/96&step[1]=setLandingPage&landingPage[1]=/wp-admin/plugins.php&step[2]=defineWpConfigConst&name[2]=IS_WP_PLAYGROUND&step[3]=setSiteName&sitename[3]=New%20Relic%20Reporting%20for%20WordPress%20Playground&tagline[3]=Trying%20out%20New%20Relic%20Reporting%20for%20WordPress.) (if it's not working try on incognito mode).

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - WordPress Playground Integration

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kmgalanakis

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
